### PR TITLE
chore: test for older versions of node

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['18', '20', '21']
+        node: ['14', '15', '16', '17', '18', '19', '20', '21']
     name: Node ${{ matrix.node }}
     # https://docs.github.com/en/actions/learn-github-actions/expressions#example
     runs-on: ubuntu-latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,12 @@ Node versions that are currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 14      | :white_check_mark: |
+| 15      | :white_check_mark: |
+| 16      | :white_check_mark: |
+| 17      | :white_check_mark: |
 | 18      | :white_check_mark: |
+| 19      | :white_check_mark: |
 | 20      | :white_check_mark: |
 | 21      | :white_check_mark: |
 


### PR DESCRIPTION
we need to at least test for older versions of node although still emphasizing 18+

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
