### PR TITLE
fix: add check in release github action for version change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ jobs:
       - name: Check if version has been updated
         id: check
         uses: EndBug/version-check@v2
+        with:
+          static-checking: localIsNew
       - name: Log when changed
         if: steps.check.outputs.changed == 'true'
         run: 'echo "Version change found in commit ${{ steps.check.outputs.commit }}! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"'


### PR DESCRIPTION
Existing bug [here](https://github.com/EndBug/version-check/issues/218)

Fix is to add the `with: static-checking: localIsNew`, mentioned in issue by author

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
