### PR TITLE
fix: exclude node 15 as supported version due to glob dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['14', '15', '16', '17', '18', '19', '20', '21']
+        node: ['14', '16', '17', '18', '19', '20', '21']
     name: Node ${{ matrix.node }}
     # https://docs.github.com/en/actions/learn-github-actions/expressions#example
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Note: ECMAScript target is ES5.
 
 ## Requirements
 
-- Node.js version 14 (with emphasis on latest LTS version, currently 18) and above.
+- Node.js version 14 or 16+, not 15.
+  - We emphasize using the latest LTS version
 - A registered app on the [Procore Developer Portal](https://developers.procore.com/).
 - A Node.js web server (such as Express) for server authentication.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Node versions that are currently being supported with security updates.
 | Version | Supported          |
 | ------- | ------------------ |
 | 14      | :white_check_mark: |
-| 15      | :white_check_mark: |
+| 15      | :x:                |
 | 16      | :white_check_mark: |
 | 17      | :white_check_mark: |
 | 18      | :white_check_mark: |

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/procore/js-sdk.git"
   },
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">=16 || 14 >=14.17"
   },
   "scripts": {
     "test": "yarn clean && yarn compile && yarn test:once",


### PR DESCRIPTION
Errored out due to glob engine specifics exluding version 15 of node [here](https://github.com/isaacs/node-glob/blob/97611cd366e5906a4c58df3f5214af843b0a5e63/package.json#L95C5-L95C33)

Our package needs to do the same

- [x] update SECURITY.md where we list supported verisons
- [x] simplify README.md where requirements list versions
- [x] exclude node 15 in tests (it is end of life anyway, ended 01 Jun 2021)

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
