### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
+      - name: Install Dependencies
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.check.outputs.changed == 'true' }}
+        run: yarn install
       - name: Compile source
         if: ${{ github.event_name == 'workflow_dispatch' || steps.check.outputs.changed == 'true' }}
         run: yarn run compile


### PR DESCRIPTION
- [x] install dependencies

Tested locally with success

<details>
<summary>yarn install</summary>

```
➜  js-sdk git:(jm-fix-release) yarn install                                                                                                                                                                                   11:30:54
yarn install v1.22.17
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 🔨  Building fresh packages...
warning Your current version of Yarn is out of date. The latest version is "1.22.19", while you're on "1.22.17".
info To upgrade, run the following command:
$ curl --compressed -o- -L https://yarnpkg.com/install.sh | bash
✨  Done in 8.21s.
```

</details>

<details>
<summary>yarn test</summary>

```
➜  js-sdk git:(jm-fix-release) yarn test                                                                                                                                                                                      11:31:17
yarn run v1.22.17
$ yarn clean && yarn compile && yarn test:once
$ rimraf dist types
$ yarn writeVer && tsc
$ cp package.json lib/version.json
$ nyc mocha -r ts-node/register test/**/*.spec.ts

...

  58 passing (218ms)

------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------|---------|----------|---------|---------|-------------------
All files         |   95.81 |    88.76 |    93.1 |   94.61 |
 authorize.ts     |     100 |      100 |     100 |     100 |
 client.ts        |    90.9 |     87.5 |   81.81 |   88.46 | 52-58,112,115,152
 clientOptions.ts |     100 |      100 |     100 |     100 |
 csrf.ts          |     100 |     90.9 |     100 |     100 | 32
 implicit.ts      |     100 |      100 |     100 |     100 |
 index.ts         |     100 |      100 |     100 |     100 |
 info.ts          |     100 |      100 |     100 |     100 |
 oauth.ts         |     100 |      100 |     100 |     100 |
 refresh.ts       |     100 |      100 |     100 |     100 |
 refresher.ts     |     100 |      100 |     100 |     100 |
 revoke.ts        |     100 |      100 |     100 |     100 |
 sdkVersion.ts    |     100 |      100 |     100 |     100 |
 token.ts         |     100 |      100 |     100 |     100 |
------------------|---------|----------|---------|---------|-------------------
✨  Done in 10.56s.
```

</details>

<details>
<summary>yarn run compile</summary>

```
➜  js-sdk git:(jm-fix-release) yarn run compile                                                                                                                                                                               11:31:30
yarn run v1.22.17
$ yarn writeVer && tsc
$ cp package.json lib/version.json
✨  Done in 3.11s.
```

</details>

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
