### PR TITLE
fix: package urls and release tagging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,4 +45,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Tag the release
         if: ${{ github.event_name == 'workflow_dispatch' || steps.check.outputs.changed == 'true' }}
-        run: git tag -a v${{ steps.check.outputs.version }} -m "v${{ steps.check.outputs.version }}"
+        uses: anothrNick/github-tag-action@1.67.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_TAG: v${{ steps.check.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
-## 4.2.0 (March 2024)
+## 4.2.1 (March 8 2024)
+
+* Update package urls to point to new repo
+* Use new GitHub Action to handle release tagging
+
+## 4.2.0 (March 7 2024)
 
 * Move repo to <https://github.com/procore-oss/js-sdk>
 * Update package.json dependencies to latest versions

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@procore/js-sdk",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A wrapper for the procore API",
   "main": "dist/index.js",
   "files": [
     "/dist"
   ],
   "types": "dist/types",
-  "homepage": "https://github.com/procore/js-sdk",
+  "homepage": "https://github.com/procore-oss/js-sdk",
   "repository": {
     "type": "git",
-    "url": "https://github.com/procore/js-sdk.git"
+    "url": "https://github.com/procore-oss/js-sdk.git"
   },
   "engines": {
     "node": ">=16 || 14 >=14.17"


### PR DESCRIPTION
- [x] use github action to handle tagging release
- [x] update package.json urls to point from github.com/procore to github.com/procore-oss

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
