### PR TITLE
chore: simplify release GitHub Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,13 +8,12 @@ on:
 permissions:
   contents: read
 jobs:
-  release:
-    permissions:
-      contents: write
+  version-check:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    env:
-      NODE_VERSION: 20
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - name: Check if version has been updated
@@ -26,26 +25,31 @@ jobs:
       - name: Log when changed
         if: steps.check.outputs.changed == 'true'
         run: 'echo "Version change found in commit ${{ steps.check.outputs.commit }}! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"'
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: version-check
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.version-check.outputs.changed == 'true'}}
+    env:
+      NODE_VERSION: 20
+    steps:
+      - uses: actions/checkout@v4
       - name: Set up node
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.check.outputs.changed == 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
       - name: Install Dependencies
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.check.outputs.changed == 'true' }}
         run: yarn install
       - name: Compile source
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.check.outputs.changed == 'true' }}
         run: yarn run compile
       - name: Publish package
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.check.outputs.changed == 'true' }}
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Tag the release
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.check.outputs.changed == 'true' }}
         uses: anothrNick/github-tag-action@1.67.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_TAG: v${{ steps.check.outputs.version }}
+          CUSTOM_TAG: v${{ needs.version-check.outputs.version }}


### PR DESCRIPTION
Move version file change check to its own job
allows us to simplify conditional checks to one
in other steps since they will be under their own
job now

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
