### PR TITLE
feat: support unversioned requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.2.2 (April 16 2025)
+
+* Add support for unversioned API requests with `version: 'unversioned'` option
+
 ## 4.2.1 (March 8 2024)
 
 * Update package urls to point to new repo
@@ -85,14 +89,14 @@ v3.0.1 Version Usage
 const procore = client(authorizer);
 
 // Default version is v1.0
-const { body } = await procore.get({ 
+const { body } = await procore.get({
   base: '/drawing_areas/{drawing_area_id}/drawings',
   params: { drawing_area_id: 42 }
 });
 // app.procore.com/rest/v1.0/drawing_areas/42/drawings
 
 // Override default version
-const { body } = await procore.get({ 
+const { body } = await procore.get({
   base: '/drawing_areas/{drawing_area_id}/drawings',
   params: { drawing_area_id: 42 },
   version: 'v1.1' });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 4.2.2 (April 16 2025)
+## 4.3.0 (April 16 2025)
 
 * Add support for unversioned API requests with `version: 'unversioned'` option
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const customFormatter = async (response) => {
 };
 
 client.get(
-  { base: "/projects" }, 
+  { base: "/projects" },
   {
     formatter: customFormatter,
     companyId: 1,
@@ -122,6 +122,7 @@ function call, or the `defaultCompanyId` value will be used when appending the
 | `client.get({ base: '/example/{id}', params: { id: 42 } })` | `https://api.procore.com/rest/v1.0/example/42` |
 | `client.get({ base: '/example/{id}', params: { id: 42 }, version: 'v1.1' })` | `https://api.procore.com/rest/v1.1/example/42` |
 | `client.get({ base: '/example/{id}', params: { id: 42 }, version: 'vapid' })` | `https://api.procore.com/vapid/example/42` |
+| `client.get({ base: '/example/{id}', params: { id: 42 }, version: 'unversioned' })` | `https://api.procore.com/example/42` |
 
 ## Responses
 
@@ -239,7 +240,7 @@ import * as sdk from '@procore/js-sdk';
 const client = client(
   authorizer,
   undefined,
-  { 
+  {
     apiHostname: "https://api.procore.com",
     defaultVersion: "v1.1",
     defaultCompanyId: 10,

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -123,7 +123,13 @@ export class Client {
       this.urlConfig(endpoint as EndpointConfig);
 
   private urlConfig = ({ base, action, params = {}, qs, version }: EndpointConfig): string => {
-    let url = `${this.options.apiHostname}/${this.version(version)}${replaceParams(base, params)}`;
+    let url: string;
+
+    if (this.version(version) === '') {
+      url = `${this.options.apiHostname}${replaceParams(base, params)}`;
+    } else {
+      url = `${this.options.apiHostname}/${this.version(version)}${replaceParams(base, params)}`;
+    }
 
     if (notNil(params.id)) {
       url = `${url}/${params.id}`;
@@ -141,15 +147,19 @@ export class Client {
   };
 
   private version = (version: string = this.options.defaultVersion): string => {
-    const [, restVersion = undefined] = version.match(/(^v[1-9]\d*\.\d+$)/) || [];
-    const [, vapidVersion = undefined] = version.match(/(^vapid)\/?$/) || [];
+    if (version === 'unversioned') {
+      return '';
+    }
+
+    const [, restVersion = undefined] = version.match(/^(v[1-9]\d*\.\d+)$/) || [];
+    const [, vapidVersion = undefined] = version.match(/^(vapid)\/?$/) || [];
 
     if (restVersion) {
       return `rest/${restVersion}`;
     } else if (vapidVersion) {
       return vapidVersion;
     } else {
-      throw new Error(`'${version}' is an invalid Procore API version`)
+      throw new Error(`'${version}' is an invalid Procore API version`);
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@procore/js-sdk",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "A wrapper for the procore API",
   "main": "dist/index.js",
   "files": [

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -337,6 +337,16 @@ describe('client', () => {
 
         fetchMock.restore();
       })
+
+      it('still work when unversioned', async () => {
+        fetchMock.get(`${HOSTNAME}/me`, me);
+
+        const { body } = await client.get({ base: '/me', version: 'unversioned' });
+        expect(body).to.eql(me);
+
+        fetchMock.restore();
+      })
+
     })
 
     describe('request using ClientOptions', () => {


### PR DESCRIPTION
Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

This pull request introduces support for "unversioned" API requests, allowing users to make requests without specifying an API version. The changes include updates to documentation, the client implementation, and tests to accommodate this new feature.

### Feature: Support for "unversioned" API requests
* **Documentation updates**:
  - Added an entry in `CHANGELOG.md` to document the new "unversioned" API request feature.
  - Updated `README.md` with an example of using the `version: 'unversioned'` option in API requests.

* **Client implementation**:
  - Modified the `urlConfig` method in `lib/client.ts` to construct URLs without a version prefix when `version: 'unversioned'` is specified.
  - Updated the `version` method in `lib/client.ts` to return an empty string for "unversioned" requests.

* **Testing**:
  - Added a new test case in `test/client.spec.ts` to verify that "unversioned" API requests function correctly.

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
